### PR TITLE
add pre-commit config for ruff linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --fix
+        language: system
+        types: [python]
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format
+        language: system
+        types: [python]


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` with ruff check + ruff format hooks

## Test plan
- [x] pre-commit hooks run on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)