### PR TITLE
Offer Google connection during onboarding

### DIFF
--- a/specs/functional/google-brief-sync.md
+++ b/specs/functional/google-brief-sync.md
@@ -40,6 +40,12 @@ Web app users who sign in with (or separately connect) a Google account.
    stored encrypted per user, and Disconnect deletes them.
 4. If Google is not connected, the calendar/email sections are simply
    omitted; the settings block explains what connecting adds.
+5. New users are offered the connection during **onboarding**, as an
+   optional step after picking feed topics: it explains what connecting
+   adds, offers "Connect Google" and "Skip for now", and only appears when
+   the server integration is configured and the account is not already
+   connected. Completing the consent flow (or skipping) lands on Home with
+   a confirmation; connecting later from Brief settings stays available.
 
 ## Acceptance Criteria
 
@@ -55,6 +61,10 @@ Web app users who sign in with (or separately connect) a Google account.
       affected section is skipped and other sections still render.
 - [ ] All Google API access is read-only scoped (gmail.readonly,
       calendar.readonly).
+- [ ] Onboarding shows the connect step only when the integration is
+      available and not yet connected; both Connect and Skip complete
+      onboarding, and the OAuth return lands the user on Home with a
+      confirmation toast.
 
 ## Edge Cases
 

--- a/specs/functional/profile-onboarding.md
+++ b/specs/functional/profile-onboarding.md
@@ -35,7 +35,13 @@ Onboarding should get the user to a personalized Home quickly. The goal is enoug
 
 - Save a display name.
 - Choose model-access mode and complete the onboarding chat.
-- Pick feed topics and land directly on Home.
+- Pick feed topics.
+- Optionally connect Google (Gmail + Calendar, read-only) so the brief can
+  plan the day and watch important email (see
+  `specs/functional/google-brief-sync.md`). The step only appears when the
+  server has the Google integration configured and the account is not
+  already connected; it is skippable, and completing or skipping it lands
+  on Home.
 
 ## Key System Components
 

--- a/specs/technical/google-brief-sync.md
+++ b/specs/technical/google-brief-sync.md
@@ -58,18 +58,23 @@ No Google SDK dependency — plain `httpx` against the REST endpoints.
   -category:promotions -category:social`, then per-message metadata
   (`From`, `Subject`, `Date`) + snippet. Normalized:
   `{from, subject, date, snippet}`.
-- State token: JWS (`jose`) `{sub, purpose:"google_oauth", exp: +10min}`
-  signed with `NEXTAUTH_SECRET`.
+- State token: JWS (`jose`) `{sub, purpose:"google_oauth", return_to,
+  exp: +10min}` signed with `NEXTAUTH_SECRET`. `return_to` is one of the
+  whitelisted keys in `RETURN_PATHS` (`brief` -> `/brief`, `onboarding` ->
+  `/onboarding`); unknown values fall back to `/brief`.
 - Secrets: `google_refresh_token`, `google_account_email`.
 
 ### Routes (`src/web/routes/google.py`) — `APIRouter(prefix="/api/google")`
 
 - `GET /api/google/status` → `{available, connected, email}` (auth required).
-- `GET /api/google/auth-url` → `{url}`; 503 when not `is_configured()`.
+- `GET /api/google/auth-url?return_to=brief|onboarding` → `{url}`; 503 when
+  not `is_configured()`. `return_to` (default `brief`) is embedded in the
+  signed state.
 - `GET /api/google/callback?code&state` — **unauthenticated** (browser
   redirect); validates the signed `state`, exchanges the code, stores
-  secrets, then 302 → `FRONTEND_ORIGIN + "/brief?google=connected"`
-  (`?google=error` on failure — never 500s to the browser).
+  secrets, then 302 → `FRONTEND_ORIGIN + <return path>` with
+  `?google=connected` (`?google=error` on failure — never 500s to the
+  browser). The return path comes from the state's whitelisted `return_to`.
 - `POST /api/google/disconnect` → deletes both secrets, `{ok: true}`.
 
 ### Brief integration
@@ -107,6 +112,12 @@ No Google SDK dependency — plain `httpx` against the REST endpoints.
   connected), Connect (`window.location.href = auth-url`), Disconnect;
   toggles for the two sections. Hidden entirely when `available` is false.
 - `/brief?google=connected|error` shows a toast once and cleans the query.
+- Onboarding (`web/src/app/(dashboard)/onboarding/page.tsx`): new `google`
+  phase after feeds are saved, shown only when `/api/google/status` reports
+  `available && !connected`; Connect uses `auth-url?return_to=onboarding`,
+  Skip completes onboarding. On return, `/onboarding?google=connected|error`
+  toasts and redirects to Home (profile + feeds were already persisted
+  before the redirect, so no onboarding state is lost).
 
 ## Validation Strategy
 

--- a/src/web/google_sync.py
+++ b/src/web/google_sync.py
@@ -31,6 +31,10 @@ ACCOUNT_EMAIL_SECRET = "google_account_email"
 STATE_TTL_MINUTES = 10
 HTTP_TIMEOUT = 20.0
 
+# Whitelisted frontend paths the OAuth callback may redirect back to.
+RETURN_PATHS = {"brief": "/brief", "onboarding": "/onboarding"}
+DEFAULT_RETURN_TO = "brief"
+
 GMAIL_QUERY = (
     "is:unread newer_than:7d (is:important OR category:primary) "
     "-category:promotions -category:social"
@@ -49,24 +53,30 @@ def _jwt_secret() -> str:
     return os.getenv("NEXTAUTH_SECRET", "")
 
 
-def make_state_token(user_id: str) -> str:
+def make_state_token(user_id: str, return_to: str = DEFAULT_RETURN_TO) -> str:
+    if return_to not in RETURN_PATHS:
+        return_to = DEFAULT_RETURN_TO
     expires = datetime.now(timezone.utc) + timedelta(minutes=STATE_TTL_MINUTES)
     return jwt.encode(
-        {"sub": user_id, "purpose": "google_oauth", "exp": expires},
+        {"sub": user_id, "purpose": "google_oauth", "return_to": return_to, "exp": expires},
         _jwt_secret(),
         algorithm="HS256",
     )
 
 
-def decode_state_token(state: str) -> str | None:
-    """Return the user id from a valid state token, else None."""
+def decode_state_token(state: str) -> tuple[str, str] | None:
+    """Return (user_id, return_path) from a valid state token, else None."""
     try:
         payload = jwt.decode(state, _jwt_secret(), algorithms=["HS256"])
     except JWTError:
         return None
     if payload.get("purpose") != "google_oauth":
         return None
-    return payload.get("sub")
+    user_id = payload.get("sub")
+    if not user_id:
+        return None
+    return_path = RETURN_PATHS.get(payload.get("return_to", ""), RETURN_PATHS[DEFAULT_RETURN_TO])
+    return user_id, return_path
 
 
 def build_auth_url(state: str) -> str:

--- a/src/web/routes/google.py
+++ b/src/web/routes/google.py
@@ -14,9 +14,9 @@ logger = structlog.get_logger()
 router = APIRouter(prefix="/api/google", tags=["google"])
 
 
-def _frontend_redirect(result: str) -> RedirectResponse:
+def _frontend_redirect(result: str, path: str = "/brief") -> RedirectResponse:
     origin = os.getenv("FRONTEND_ORIGIN", "http://localhost:3000")
-    return RedirectResponse(url=f"{origin}/brief?google={result}", status_code=302)
+    return RedirectResponse(url=f"{origin}{path}?google={result}", status_code=302)
 
 
 @router.get("/status")
@@ -31,10 +31,13 @@ async def google_status(user: dict = Depends(get_current_user)):
 
 
 @router.get("/auth-url")
-async def google_auth_url(user: dict = Depends(get_current_user)):
+async def google_auth_url(
+    return_to: str = Query("brief"),
+    user: dict = Depends(get_current_user),
+):
     if not google_sync.is_configured():
         raise HTTPException(status_code=503, detail="Google integration is not configured")
-    state = google_sync.make_state_token(user["id"])
+    state = google_sync.make_state_token(user["id"], return_to=return_to)
     return {"url": google_sync.build_auth_url(state)}
 
 
@@ -48,20 +51,21 @@ async def google_callback(
     if error or not code or not state:
         return _frontend_redirect("error")
 
-    user_id = google_sync.decode_state_token(state)
-    if not user_id:
+    decoded = google_sync.decode_state_token(state)
+    if not decoded:
         return _frontend_redirect("error")
+    user_id, return_path = decoded
 
     try:
         tokens = google_sync.exchange_code(code)
     except Exception as exc:
         logger.warning("google.code_exchange_failed", error=str(exc))
-        return _frontend_redirect("error")
+        return _frontend_redirect("error", return_path)
 
     refresh_token = tokens.get("refresh_token")
     if not refresh_token:
         logger.warning("google.no_refresh_token", user_id=user_id)
-        return _frontend_redirect("error")
+        return _frontend_redirect("error", return_path)
 
     email = None
     access_token = tokens.get("access_token")
@@ -72,9 +76,9 @@ async def google_callback(
         google_sync.store_connection(user_id, refresh_token, email)
     except Exception as exc:
         logger.warning("google.store_connection_failed", error=str(exc))
-        return _frontend_redirect("error")
+        return _frontend_redirect("error", return_path)
 
-    return _frontend_redirect("connected")
+    return _frontend_redirect("connected", return_path)
 
 
 @router.post("/disconnect")

--- a/tests/web/test_google_routes.py
+++ b/tests/web/test_google_routes.py
@@ -39,6 +39,42 @@ def test_auth_url_shape(client, auth_headers, google_env):
     assert "state=" in url
 
 
+def test_state_token_return_to_roundtrip():
+    state = google_sync.make_state_token("test:u", return_to="onboarding")
+    assert google_sync.decode_state_token(state) == ("test:u", "/onboarding")
+
+    # Unknown return_to values fall back to the brief page.
+    state = google_sync.make_state_token("test:u", return_to="https://evil.example")
+    assert google_sync.decode_state_token(state) == ("test:u", "/brief")
+
+
+def test_auth_url_embeds_return_to(client, auth_headers, google_env):
+    resp = client.get("/api/v1/google/auth-url?return_to=onboarding", headers=auth_headers)
+    assert resp.status_code == 200
+    from urllib.parse import parse_qs, urlparse
+
+    state = parse_qs(urlparse(resp.json()["url"]).query)["state"][0]
+    _user, path = google_sync.decode_state_token(state)
+    assert path == "/onboarding"
+
+
+def test_callback_redirects_to_onboarding_return_path(client, google_env):
+    state = google_sync.make_state_token("test:user-ob", return_to="onboarding")
+    with (
+        patch(
+            "web.google_sync.exchange_code",
+            return_value={"refresh_token": "rt-ob", "access_token": "at-ob"},
+        ),
+        patch("web.google_sync.fetch_profile_email", return_value="ob@gmail.test"),
+    ):
+        resp = client.get(
+            f"/api/v1/google/callback?code=abc&state={state}",
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    assert "/onboarding?google=connected" in resp.headers["location"]
+
+
 def test_callback_rejects_bad_state(client, google_env):
     resp = client.get(
         "/api/v1/google/callback?code=abc&state=not-a-valid-token",

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -10917,6 +10917,18 @@
     "/api/google/auth-url": {
       "get": {
         "operationId": "google_auth_url_api_google_auth_url_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "return_to",
+            "required": false,
+            "schema": {
+              "default": "brief",
+              "title": "Return To",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -10925,6 +10937,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [

--- a/web/src/app/(dashboard)/onboarding/page.tsx
+++ b/web/src/app/(dashboard)/onboarding/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useRef, useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Brain,
   BookOpen,
+  CalendarDays,
+  Mail,
   FileText,
   GitMerge,
   GraduationCap,
@@ -45,7 +47,7 @@ import { useToken } from "@/hooks/useToken";
 import { apiFetch } from "@/lib/api";
 import { toast } from "sonner";
 
-type Phase = "intro" | "name" | "welcome" | "chat" | "feeds" | "guide" | "done";
+type Phase = "intro" | "name" | "welcome" | "chat" | "feeds" | "google" | "guide" | "done";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -178,7 +180,10 @@ export const behindTheScenesCards = [
 export default function OnboardingPage() {
   const token = useToken();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [phase, setPhase] = useState<Phase>("name");
+  const [googleAvailable, setGoogleAvailable] = useState(false);
+  const [connectingGoogle, setConnectingGoogle] = useState(false);
   const [provider, setProvider] = useState("auto");
   const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
@@ -259,6 +264,45 @@ export default function OnboardingPage() {
   const handleDone = useCallback(() => {
     router.replace("/home");
   }, [router]);
+
+  // Returning from the Google consent flow: onboarding data was persisted
+  // before the redirect. Success shows the done screen (auto-redirects home);
+  // failure lands on Brief settings where the retry button lives.
+  useEffect(() => {
+    const result = searchParams.get("google");
+    if (!result) return;
+    if (result === "connected") {
+      toast.success("Google connected — your brief will plan your day and watch your inbox");
+      setPhase("done");
+    } else {
+      router.replace("/brief?google=error");
+    }
+  }, [searchParams, router]);
+
+  // Offer the Google step only when the server integration is configured
+  // and this account is not already connected.
+  useEffect(() => {
+    if (!token) return;
+    apiFetch<{ available: boolean; connected: boolean }>("/api/v1/google/status", {}, token)
+      .then((status) => setGoogleAvailable(status.available && !status.connected))
+      .catch(() => setGoogleAvailable(false));
+  }, [token]);
+
+  const handleConnectGoogle = async () => {
+    if (!token || connectingGoogle) return;
+    setConnectingGoogle(true);
+    try {
+      const { url } = await apiFetch<{ url: string }>(
+        "/api/v1/google/auth-url?return_to=onboarding",
+        {},
+        token,
+      );
+      window.location.href = url;
+    } catch (e) {
+      toast.error((e as Error).message);
+      setConnectingGoogle(false);
+    }
+  };
 
   // Auto-redirect after done
   useEffect(() => {
@@ -442,7 +486,11 @@ export default function OnboardingPage() {
         token,
       );
       setFeedsAdded(res.feeds_added);
-      handleDone();
+      if (googleAvailable) {
+        setPhase("google");
+      } else {
+        handleDone();
+      }
     } catch (e) {
       toast.error((e as Error).message);
     } finally {
@@ -773,6 +821,72 @@ export default function OnboardingPage() {
               >
                 {savingFeeds ? "Adding feeds..." : "Continue"}
                 {!savingFeeds && <ArrowRight className="ml-2 h-4 w-4" />}
+              </Button>
+              <button
+                onClick={handleDone}
+                className="mt-2 w-full text-center text-xs text-muted-foreground hover:text-foreground"
+              >
+                Skip for now
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === "google" && (
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="px-6 pt-6 pb-2 text-center">
+              <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+                <CalendarDays className="h-6 w-6 text-primary" />
+              </div>
+              <h2 className="text-lg font-semibold">Plan your day automatically</h2>
+              <p className="text-sm text-muted-foreground">
+                Connect Google so your brief knows what&apos;s coming up and
+                which emails matter.
+              </p>
+            </div>
+
+            <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
+              <div className="flex gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+                  <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Coming up</p>
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    Each brief opens with today&apos;s schedule and a short
+                    outlook for the week — busy days, deadlines, open
+                    stretches.
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+                  <Mail className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Inbox watch</p>
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    Unread emails that actually need attention, prioritized —
+                    who it&apos;s from, what it&apos;s about, and what to do
+                    next.
+                  </p>
+                </div>
+              </div>
+              <div className="rounded-lg border bg-muted/50 p-3 text-xs text-muted-foreground leading-relaxed">
+                <span className="font-medium text-foreground">Read-only.</span>{" "}
+                StewardMe can never send email or change events, and you can
+                disconnect anytime from Brief settings.
+              </div>
+            </div>
+
+            <div className="border-t px-6 py-4">
+              <Button
+                onClick={handleConnectGoogle}
+                disabled={connectingGoogle}
+                className="w-full"
+              >
+                {connectingGoogle ? "Opening Google..." : "Connect Google"}
+                {!connectingGoogle && <ArrowRight className="ml-2 h-4 w-4" />}
               </Button>
               <button
                 onClick={handleDone}

--- a/web/src/types/api.generated.ts
+++ b/web/src/types/api.generated.ts
@@ -1,6 +1,6 @@
 // This file is generated. Do not edit manually.
 // Source: web/openapi.json
-// OpenAPI SHA256: ddff8d279504e6545deb86fbaaba70d70fc437b1a0ff5faf9ac7f102467a1a47
+// OpenAPI SHA256: d90a8bb2256b5710d0177c761c85b04125b3d653b4c79e54c62d26e0735cae90
 export interface paths {
     "/api/admin/stats": {
         parameters: {
@@ -9229,7 +9229,9 @@ export interface operations {
     };
     google_auth_url_api_google_auth_url_get: {
         parameters: {
-            query?: never;
+            query?: {
+                return_to?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -9243,6 +9245,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Adds an optional **Connect Google** step to onboarding, right after feed selection: it explains what connecting adds (day/week planning and inbox watch in the brief), notes the access is read-only, and offers "Connect Google" or "Skip for now". The step only appears when the server has the Google integration configured and the account isn't already connected — everyone else skips straight past it.
- The OAuth round-trip now knows where it started: the signed state token carries a **whitelisted** `return_to` (`brief` or `onboarding`; anything else falls back to `/brief`, so the callback can never be steered off-app). Success returns to onboarding and shows the "You're all set!" screen (auto-redirects to Home); failure lands on `/brief?google=error`, where the error toast and the retry button live.
- Why: new users previously only discovered the Google connection if they happened to visit the Brief page.

## Linked Context

- Issue: none (direct request)
- Manifest feature id: `profile-onboarding` (touched surface)
- Functional spec: `specs/functional/profile-onboarding.md` and `specs/functional/google-brief-sync.md` updated
- Technical spec: `specs/technical/google-brief-sync.md` updated

## Scope

- User-facing behavior changed: new optional onboarding step; feed-save previously went straight to Home and still does when the Google step isn't applicable
- Internal-only refactor: `decode_state_token` now returns `(user_id, return_path)`
- API or schema changed: `GET /api/google/auth-url` gains an optional `return_to` query param; contracts regenerated

## Validation

- Tests run: new tests for the state-token `return_to` round-trip (including the open-redirect fallback for unknown values), auth-url embedding, and callback redirect to `/onboarding`; full `tests/web` suite and e2e suite (13/13) pass.
- Lint/type/build run: ruff, `npm run lint`, `typecheck`, `build` — all pass.
- Contracts regenerated/checked: yes, `check_contracts.py` passes.
- Any validation intentionally skipped: real Google consent completion (needs real OAuth credentials). The return path was verified live in a browser: `/onboarding?google=connected` renders the completion screen and auto-redirects to Home.

## Risks

- Main risk area: the onboarding flow ordering — the step is additive after feeds are persisted, so nothing client-side is lost across the OAuth redirect; skipping preserves the exact previous behavior.
- Rollback or containment plan: revert the commit; no data-shape changes.

## Checklist

- [x] I updated `specs/catalog.yaml`, or confirmed the spec tree did not change. (No tree change — existing specs edited.)
- [x] I updated `specs/manifest.yaml` if tracked feature ownership, tests, or validation commands changed. (None changed.)
- [x] I updated the relevant functional spec, or this change is spec-neutral.
- [x] I updated the relevant technical spec, or this change does not alter implementation expectations.
- [x] I added or updated tests where behavior changed.
- [x] I updated both backend and frontend contract types if payloads changed.
- [x] I ran the smallest meaningful validation commands for this change and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWVBa9RLZUPS3usZvM867s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWVBa9RLZUPS3usZvM867s)_